### PR TITLE
Revert "Bump Microsoft.AspNetCore.All from 2.0.3 to 2.0.9 in /Dev/src/models"

### DIFF
--- a/Dev/src/models/models.csproj
+++ b/Dev/src/models/models.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Revert the version update since this breaks the build. Will do a proper dotnet version upgrade soon.